### PR TITLE
chore:bump deps, suppress java 21 warning, bump version 0.0.5-SNAPSHOT to 0.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.molgenis</groupId>
     <artifactId>vip-web</artifactId>
-    <version>0.0.5-SNAPSHOT</version>
+    <version>0.0.5</version>
     <name>vip-web</name>
     <description>Variant Interpretation Pipeline web interface backend</description>
     <packaging>pom</packaging>

--- a/vip-web-backend/pom.xml
+++ b/vip-web-backend/pom.xml
@@ -5,16 +5,16 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.3.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.molgenis</groupId>
     <artifactId>vip-web-backend</artifactId>
-    <version>0.0.5-SNAPSHOT</version>
+    <version>0.0.5</version>
     <packaging>jar</packaging>
     <properties>
         <java.version>21</java.version>
-        <samtools.htsjdk.version>4.1.1</samtools.htsjdk.version>
+        <samtools.htsjdk.version>4.1.3</samtools.htsjdk.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -140,6 +140,14 @@
                             <artifactId>lombok</artifactId>
                         </exclude>
                     </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- suppress Java 21 dynamic agent loading warning, since there is no suitable fix yet -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-XX:+EnableDynamicAgentLoading</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/vip-web-frontend/pom.xml
+++ b/vip-web-frontend/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.molgenis</groupId>
     <artifactId>vip-web-frontend</artifactId>
-    <version>0.0.4-SNAPSHOT</version>
+    <version>0.0.5</version>
     <packaging>pom</packaging>
 
     <build>
@@ -12,7 +12,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.15.0</version>
+                <version>1.15.1</version>
                 <executions>
                     <execution>
                         <id>install node and pnpm</id>


### PR DESCRIPTION
chore:bump htsjdk 4.1.1 to 4.1.3
chore:bump spring-boot-starter-parent 3.3.4 to 3.3.6
chore:bump frontend-maven-plugin 1.15.0 to 1.15.1
chore:suppress Java 21 dynamic agent loading warning